### PR TITLE
Use symfony's ArgvInput to avoid type exceptions

### DIFF
--- a/Classes/Task/CommandExecutor.php
+++ b/Classes/Task/CommandExecutor.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace Helhum\TYPO3\Crontab\Task;
 
-use Helhum\Typo3Console\Mvc\Cli\Symfony\Input\ArgvInput;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;


### PR DESCRIPTION
The `application->run` call needs to be called with `ArvgInput` which breaks if initialized with an array:

```
Core: Exception handler (CLI): Uncaught TYPO3 Exception: Helhum\Typo3Console\Mvc\Cli\Symfony\Input\ArgvInput::__construct(): Argument #1 ($input) must be of type ?Symfony\Component\Console\Input\InputInterface, array given, called in /var/www/vendor/helhum/typo3-crontab/Classes/Task/CommandExecutor.php on line 37 | TypeError thrown in file /var/www/vendor/helhum/typo3-console/Classes/Console/Mvc/Cli/Symfony/Input/ArgvInput.php in line 21
```

Using Symfony's `ArvgInput` implementation solves the issue. The special implementation details of `helhum/console`'s `ArvgInput` are not used anywhere in this extension. Thus we can switch to the one from Symfony Console.