### PR TITLE
[BUGFIX] Avoid TypeError when dispatching commands

### DIFF
--- a/Classes/Task/CommandExecutor.php
+++ b/Classes/Task/CommandExecutor.php
@@ -4,6 +4,7 @@ namespace Helhum\TYPO3\Crontab\Task;
 
 use Helhum\Typo3Console\Mvc\Cli\Symfony\Input\ArgvInput;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput as SymfonyArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -34,7 +35,7 @@ class CommandExecutor implements TaskExecutor
         array_unshift($argv, '_');
         $output = $output ?? new NullOutput();
 
-        return $application->run(new ArgvInput($argv), $output) === 0;
+        return $application->run(new ArgvInput(new SymfonyArgvInput($argv)), $output) === 0;
     }
 
     public function getTitle(): ?string


### PR DESCRIPTION
`helhum/typo3-console` changed the constructor signature of `\Helhum\Typo3Console\Mvc\Cli\Symfony\Input\ArgvInput` and expects now directly an `InputInterface` and does no longer supports an array.

As `EXT:crontab` needs to pass arguments as an array, this change creates an symfony ArgvInput object passing in the argument array and use that instead of the array as before.

That helps to mitigate spamming TypeErrors dispatching commands like following:

```
Core: Exception handler (CLI): Uncaught TYPO3 Exception:
Helhum\Typo3Console\Mvc\Cli\Symfony\Input\ArgvInput::__construct():
Argument #1 ($input) must be of type ?Symfony\Component\Console\Input\InputInterface,
array given, called in vendor/helhum/typo3-crontab/Classes/Task/CommandExecutor.php
on line 37

TypeError thrown in file vendor/helhum/typo3-console/Classes/Console/Mvc/Cli/Symfony/Input/ArgvInput.php
in line 21
```